### PR TITLE
(fix): Check if search is performed

### DIFF
--- a/components/SearchInput.vue
+++ b/components/SearchInput.vue
@@ -13,7 +13,7 @@ watch(search, (value) => {
     name="search"
     id="search"
     v-model="search"
-    placeholder="Search..."
+    placeholder="Search a community..."
     class="w-80"
   />
 </template>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -8,7 +8,7 @@ const searchTerm = ref("");
 const filteredCommunities: Ref<CommunityInterface[]> = ref([]);
 
 const isSearchResultsEmpty = computed(
-  () => filteredCommunities.value.length === 0
+  () => filteredCommunities.value.length === 0 && searchTerm.value
 );
 
 onMounted(() => {


### PR DESCRIPTION
Check that search results are empty only when the search is performed. To ensure that when you come to the page before the communities are loaded, you don't get the message saying that no communities have been found.